### PR TITLE
add super admin in seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ erl_crash.dump
 /.vagrant
 deploy_key
 ubuntu-xenial-16.04-cloudimg-console.log
+
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -22,3 +22,13 @@ the SU
 + Content changes to make things clearer to the intended audience
 + Some changes to the branding and user interface to bring this more in line with
 Oxleas' desired brand name.
+
+## Super Admin user
+
+When running the project on your machine, you can populate the database with users by running:
+```
+mix run apps/healthlocker/priv/repo/user_only_seeds.exs
+```
+
+The list of users will include a super admin (super@admin.com/password).
+Once logged-in with this user you can add more users directly with the application UI.

--- a/apps/healthlocker/priv/repo/user_only_seeds.exs
+++ b/apps/healthlocker/priv/repo/user_only_seeds.exs
@@ -35,3 +35,15 @@ Repo.insert!(%User{
   data_access: false,
   role: "slam_user"
 })
+
+Repo.insert!(%User{
+  email: "super@admin.com",
+  password_hash: Comeonin.Bcrypt.hashpwsalt("password"),
+  first_name: "Super",
+  last_name: "Admin",
+  phone_number: "07519 283 475",
+  security_question: "Name of first boss?",
+  security_answer: "Betty",
+  data_access: false,
+  role: "super_admin"
+})

--- a/apps/oxleas_adhd/config/config.exs
+++ b/apps/oxleas_adhd/config/config.exs
@@ -1,7 +1,7 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
-
+config :oxleas_adhd, ecto_repos: []
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
 # file won't be loaded nor affect the parent project. For this reason,


### PR DESCRIPTION
ref: https://github.com/healthlocker/oxleas-adhd/issues/254#issuecomment-357955408

Add a `super_admin` user in seed to not have to add it manually each time the database is dropped or when the project is cloned.